### PR TITLE
Fix SaveLoadSystem version parsing

### DIFF
--- a/Assets/Scripts/Systems/SaveLoadSystem.cs
+++ b/Assets/Scripts/Systems/SaveLoadSystem.cs
@@ -58,19 +58,21 @@ public partial class SaveLoadSystem : SystemBase
         int i = 0;
         try
         {
+            // Read and validate save version once at the beginning of the file
+            Version saveVersion = ReadVersion(bytes, ref i);
+            if (!IsSaveVersionCompatible(saveVersion))
+            {
+                Debug.LogError($"Save version {saveVersion} is not compatible with current version {GameController.Version}");
+                OnLoad?.Invoke(false);
+                return;
+            }
+
             while (i < bytes.Length)
             {
                 // Read saveable component
                 int id;
                 SaveableComponent.SaveableType type;
                 (id, type) = ReadSaveable(bytes, ref i);
-                Version saveVersion = ReadVersion(bytes, ref i);
-                if(!IsSaveVersionCompatible(saveVersion))
-                {
-                    Debug.LogError($"Save version {saveVersion} is not compatible with current version {GameController.Version}");
-                    OnLoad?.Invoke(false);
-                    return;
-                }
                 NativeList<byte> list = new NativeList<byte>(Allocator.TempJob);
                 switch (type)
                 {


### PR DESCRIPTION
## Summary
- fix `LoadGame` so it reads the save file version only once at the start

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68453da1f9ec8333b818c1ae64ad905a